### PR TITLE
Remove google analytics

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -21,7 +21,6 @@ footnotereturnlinkcontents = "↩"
 [params]
   twitterName = "antifuchs"
   githubName = "antifuchs"
-  google_analytics = "UA-20002026-1"
   hideShareOptions = true
 
 [blackfriday]
@@ -51,13 +50,8 @@ home = [ "HTML", "RSS", "JSON"]
   [privacy.disqus]
     disable = true
   [privacy.googleAnalytics]
-    # We use google analytics, but only with anonymized user data, and
-    # with non-permanent tracking (it uses session data instead of
-    # cookies).
-    disable = false
-    anonymizeIP = true
-    respectDoNotTrack = true
-    useSessionStorage = true
+    # Turning that off
+    disable = true
   [privacy.instagram]
     disable = true
   [privacy.speakerDeck]

--- a/content/page/privacy.md
+++ b/content/page/privacy.md
@@ -17,7 +17,6 @@ If any lawyers come knocking, this is the policy that is current & applies to th
 Unfortunately for you and me, this policy gives me way more permission do to stuff with your data than I'm comfortable with. So here's the exact things I additionally do to keep away from your personal data:
 
 * I configure [hugo with fairly strict privacy settings](https://gohugo.io/about/hugo-and-gdpr/) - here's the [config file](https://github.com/antifuchs/weblog/blob/master/config.toml):
-  * This site uses Google Analytics, but with anonymized IP addresses and without cookies (this uses session storage only - if you want to get untracked, restart your browser).
   * No automated embeds at all - I have disabled twitter, instagram and youtube embedding (unsure if I've ever even had any of those).
 * This site doesn't set cookies.
 

--- a/content/page/privacy.md
+++ b/content/page/privacy.md
@@ -17,6 +17,7 @@ If any lawyers come knocking, this is the policy that is current & applies to th
 Unfortunately for you and me, this policy gives me way more permission do to stuff with your data than I'm comfortable with. So here's the exact things I additionally do to keep away from your personal data:
 
 * I configure [hugo with fairly strict privacy settings](https://gohugo.io/about/hugo-and-gdpr/) - here's the [config file](https://github.com/antifuchs/weblog/blob/master/config.toml):
+  * No tracking via google analytics or other services. I don't care very much about visitor numbers or where you came from.
   * No automated embeds at all - I have disabled twitter, instagram and youtube embedding (unsure if I've ever even had any of those).
 * This site doesn't set cookies.
 

--- a/layouts/page/page.html
+++ b/layouts/page/page.html
@@ -14,7 +14,5 @@
         </div>
     </div>
 </div>
-
-{{ partial "analytics.html" . }}
 </body>
 </html>


### PR DESCRIPTION
I don't care about these numbers, they have been less than awesome to set up now that they are switching to version 4, and provide an overall hateful experience to users. Let's turn it off.